### PR TITLE
戻るボタンがネットワークハングでブロックされる問題を修正

### DIFF
--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/data/di/NetworkModule.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/data/di/NetworkModule.kt
@@ -6,6 +6,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import jp.itIsNoMatter.routineTimerClone.data.remote.datasource.RoutineRemoteDataSource
@@ -29,6 +30,12 @@ object NetworkModule {
                         prettyPrint = true
                     },
                 )
+            }
+            // 接続先に到達できない場合でも無期限に待たされないようにするタイムアウト設定
+            install(HttpTimeout) {
+                connectTimeoutMillis = 5000
+                requestTimeoutMillis = 8000
+                socketTimeoutMillis = 8000
             }
         }
     }

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineCreate/RoutineCreateViewModel.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineCreate/RoutineCreateViewModel.kt
@@ -1,5 +1,6 @@
 package jp.itIsNoMatter.routineTimerClone.ui.routineCreate
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -105,14 +106,19 @@ class RoutineCreateViewModel
         fun onClickBackButton() {
             val state = uiState.value
             viewModelScope.launch {
-                if (state is RoutineCreateUiState.Done) {
-                    routineRepository.updateRoutine(state.routine)
+                try {
+                    if (state is RoutineCreateUiState.Done) {
+                        if (state.routine.name.isBlank()) {
+                            routineRepository.deleteRoutineById(state.routine.id)
+                        } else {
+                            routineRepository.updateRoutine(state.routine)
+                        }
+                    }
+                } catch (e: Exception) {
+                    Log.e("RoutineCreateViewModel", "Failed to persist routine on back", e)
+                } finally {
+                    _navigateTo.emit(NavEvent.NavigateBack)
                 }
-
-                if (state is RoutineCreateUiState.Done && state.routine.name.isBlank()) {
-                    routineRepository.deleteRoutineById(state.routine.id)
-                }
-                _navigateTo.emit(NavEvent.NavigateBack)
             }
         }
     }

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineEdit/RoutineEditScreen.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineEdit/RoutineEditScreen.kt
@@ -17,9 +17,6 @@ fun RoutineEditScreen(
     navHostController: NavHostController,
     viewModel: RoutineEditViewModel = hiltViewModel(),
 ) {
-    BackHandler {
-        viewModel.onBackScreen()
-    }
     LaunchedEffect(Unit) {
         viewModel.fetch(routineId)
     }
@@ -37,6 +34,7 @@ fun RoutineEditScreen(
             Text("Loading ...")
         }
         is RoutineEditUiState.Done -> {
+            BackHandler(onBack = viewModel::onBackScreen)
             val doneRoutine = uiState.routine
             RoutineEditContent(
                 routine = doneRoutine,

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineEdit/RoutineEditViewModel.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineEdit/RoutineEditViewModel.kt
@@ -1,5 +1,6 @@
 package jp.itIsNoMatter.routineTimerClone.ui.routineEdit
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -71,10 +72,18 @@ class RoutineEditViewModel
         }
 
         fun onBackScreen() {
+            val state = uiState.value
             viewModelScope.launch {
-                deleteInvalidTasks()
-                routineRepository.updateRoutine((uiState.value as RoutineEditUiState.Done).routine)
-                _navigateTo.emit(NavEvent.NavigateBack)
+                try {
+                    if (state is RoutineEditUiState.Done) {
+                        deleteInvalidTasks()
+                        routineRepository.updateRoutine(state.routine)
+                    }
+                } catch (e: Exception) {
+                    Log.e("RoutineEditViewModel", "Failed to persist routine on back", e)
+                } finally {
+                    _navigateTo.emit(NavEvent.NavigateBack)
+                }
             }
         }
 


### PR DESCRIPTION
## 概要
戻るボタンがネットワークハングでブロックされる問題を修正。HTTPクライアントにタイムアウトを設定し、RoutineCreate/RoutineEditの戻る処理を保存失敗時にも必ず画面遷移するようにした。

## 変更内容
- `NetworkModule.kt`: `HttpClient` に `HttpTimeout` を追加し、接続先に到達できない場合でも無期限に待たされないようにした（connect: 5s, request/socket: 8s）
- `RoutineCreateViewModel.kt`: 戻るボタン処理を `try/catch/finally` で囲み、保存処理が失敗しても必ず `NavigateBack` を発火するように修正。ルーティン名が空の場合の削除と更新の分岐も整理
- `RoutineEditViewModel.kt`: 同様に戻るボタン処理を `try/catch/finally` で囲み、保存失敗時も必ず画面遷移するように修正
- `RoutineEditScreen.kt`: `BackHandler` を `Done` 状態内に限定し、`Loading` 中に発生していた強制キャストクラッシュを防止

## 動作確認
本セッションではビルド・テストを実行していないため未確認です。レビュー時にご確認をお願いします。

## 補足
特になし
