### PR TITLE
RoutineList画面でFABと再生ボタンが重ならないよう修正

### DIFF
--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineList/RoutineListScreen.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineList/RoutineListScreen.kt
@@ -2,6 +2,7 @@ package jp.itIsNoMatter.routineTimerClone.ui.routineList
 
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -36,12 +37,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import jp.itIsNoMatter.routineTimerClone.domain.model.Routine
 import jp.itIsNoMatter.routineTimerClone.ui.navigation.Route
+
+private val FabClearance = 88.dp
 
 @Composable
 fun RoutineListScreen(
@@ -109,9 +113,11 @@ fun RoutineCard(
     }
 }
 
+internal const val ROUTINE_LIST_TEST_TAG = "routineList"
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun RoutineListContent(
+internal fun RoutineListContent(
     routines: List<Routine>,
     onRoutineClick: (routineId: String) -> Unit = {},
     onPlayButtonClick: (routineId: String) -> Unit = {},
@@ -172,7 +178,9 @@ private fun RoutineListContent(
             modifier =
                 Modifier
                     .padding(innerPadding)
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    .testTag(ROUTINE_LIST_TEST_TAG),
+            contentPadding = PaddingValues(bottom = FabClearance),
         ) {
             items(routines) { routine ->
                 RoutineCard(

--- a/app/src/test/java/jp/itIsNoMatter/routineTimerClone/ui/routineList/RoutineListScreenTest.kt
+++ b/app/src/test/java/jp/itIsNoMatter/routineTimerClone/ui/routineList/RoutineListScreenTest.kt
@@ -1,0 +1,47 @@
+package jp.itIsNoMatter.routineTimerClone.ui.routineList
+
+import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
+import jp.itIsNoMatter.routineTimerClone.domain.model.Routine
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h891dp")
+class RoutineListScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val routines = (1..20).map { Routine(it.toString(), "Routine $it", emptyList()) }
+
+    @Test
+    fun `末尾までスクロールしても再生ボタンがFABと重ならない`() {
+        composeTestRule.setContent {
+            RoutineListContent(routines = routines)
+        }
+
+        composeTestRule.onNodeWithTag(ROUTINE_LIST_TEST_TAG).performTouchInput {
+            repeat(8) { swipeUp() }
+        }
+        composeTestRule.waitForIdle()
+
+        val fabBounds = composeTestRule.onNodeWithContentDescription("Add Routine").getBoundsInRoot()
+        val lastPlayButtonBounds =
+            composeTestRule
+                .onAllNodesWithContentDescription("Start Routine")
+                .onLast()
+                .getBoundsInRoot()
+
+        assertTrue(lastPlayButtonBounds.bottom <= fabBounds.top)
+    }
+}

--- a/app/src/test/java/jp/itIsNoMatter/routineTimerClone/ui/routinelist/RoutineListScreenTest.kt
+++ b/app/src/test/java/jp/itIsNoMatter/routineTimerClone/ui/routinelist/RoutineListScreenTest.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.routineList
+package jp.itIsNoMatter.routineTimerClone.ui.routinelist
 
 import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule


### PR DESCRIPTION
## 概要
RoutineList画面で、FloatingActionButton(ルーチン追加ボタン)がリスト末尾のカードの再生ボタンと重なり、操作不能になる不具合を修正します。

## 変更内容
- `RoutineListScreen.kt`のLazyColumnに`contentPadding(bottom = 88.dp)`を追加し、FAB分の余白を確保
- 末尾までスクロールしても再生ボタンがFABと重ならないことを検証するCompose UIテスト(Robolectric)を追加

## 動作確認
`./gradlew clean ktlintCheck testDebugUnitTest` を実行し、新規テストを含め全て成功することを確認しました。

## Close対象
close #148

## 補足
特になし
