### PR TITLE
ui配下のpackage名をKotlinの命名規約に統一

### DIFF
--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/navigation/EEffortNavGraph.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/navigation/EEffortNavGraph.kt
@@ -6,10 +6,10 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
-import jp.itIsNoMatter.routineTimerClone.ui.routineCreate.RoutineCreateScreen
-import jp.itIsNoMatter.routineTimerClone.ui.routineEdit.RoutineEditScreen
-import jp.itIsNoMatter.routineTimerClone.ui.routineList.RoutineListScreen
-import jp.itIsNoMatter.routineTimerClone.ui.runRoutine.runRoutineScreen
+import jp.itIsNoMatter.routineTimerClone.ui.routinecreate.RoutineCreateScreen
+import jp.itIsNoMatter.routineTimerClone.ui.routineedit.RoutineEditScreen
+import jp.itIsNoMatter.routineTimerClone.ui.routinelist.RoutineListScreen
+import jp.itIsNoMatter.routineTimerClone.ui.runroutine.runRoutineScreen
 import jp.itIsNoMatter.routineTimerClone.ui.task.create.TaskCreateScreen
 import jp.itIsNoMatter.routineTimerClone.ui.task.edit.TaskEditScreen
 

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinecreate/RoutineCreateScreen.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinecreate/RoutineCreateScreen.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.routineEdit
+package jp.itIsNoMatter.routineTimerClone.ui.routinecreate
 
 import android.util.Log
 import androidx.activity.compose.BackHandler
@@ -12,13 +12,12 @@ import jp.itIsNoMatter.routineTimerClone.ui.components.RoutineEditContent
 import jp.itIsNoMatter.routineTimerClone.ui.navigation.NavEvent
 
 @Composable
-fun RoutineEditScreen(
-    routineId: String,
+fun RoutineCreateScreen(
     navHostController: NavHostController,
-    viewModel: RoutineEditViewModel = hiltViewModel(),
+    viewModel: RoutineCreateViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(Unit) {
-        viewModel.fetch(routineId)
+        viewModel.create()
     }
     LaunchedEffect(Unit) {
         viewModel.navigateTo.collect { event ->
@@ -28,24 +27,23 @@ fun RoutineEditScreen(
             }
         }
     }
-
     when (val uiState = viewModel.uiState.collectAsState().value) {
-        is RoutineEditUiState.Loading -> {
+        is RoutineCreateUiState.Loading -> {
             Text("Loading ...")
         }
-        is RoutineEditUiState.Done -> {
-            BackHandler(onBack = viewModel::onBackScreen)
+        is RoutineCreateUiState.Done -> {
+            BackHandler(onBack = viewModel::onClickBackButton)
             val doneRoutine = uiState.routine
             RoutineEditContent(
                 routine = doneRoutine,
                 onRoutineTitleChange = viewModel::onRoutineTitleChange,
                 onClickAddButton = viewModel::onClickAddTaskButton,
                 onClickTaskCard = viewModel::onClickTaskCard,
-                onClickBackButton = viewModel::onBackScreen,
+                onClickBackButton = viewModel::onClickBackButton,
             )
         }
-        is RoutineEditUiState.Error -> {
-            Log.e("RoutineEditScreen", "Error: ${uiState.e}")
+        is RoutineCreateUiState.Error -> {
+            Log.e("RoutineCreateScreen", "Error: ${uiState.e}")
         }
     }
 }

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinecreate/RoutineCreateUiState.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinecreate/RoutineCreateUiState.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.routineCreate
+package jp.itIsNoMatter.routineTimerClone.ui.routinecreate
 
 import jp.itIsNoMatter.routineTimerClone.domain.model.Routine
 

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinecreate/RoutineCreateViewModel.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinecreate/RoutineCreateViewModel.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.routineEdit
+package jp.itIsNoMatter.routineTimerClone.ui.routinecreate
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.itIsNoMatter.routineTimerClone.core.getOrNull
 import jp.itIsNoMatter.routineTimerClone.data.repository.RoutineRepository
+import jp.itIsNoMatter.routineTimerClone.domain.model.Routine
 import jp.itIsNoMatter.routineTimerClone.ui.navigation.NavEvent
 import jp.itIsNoMatter.routineTimerClone.ui.navigation.Route
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -18,15 +19,42 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class RoutineEditViewModel
+class RoutineCreateViewModel
     @Inject
     constructor(
         private val routineRepository: RoutineRepository,
     ) : ViewModel() {
-        private val _uiState = MutableStateFlow<RoutineEditUiState>(RoutineEditUiState.Loading)
-        val uiState: StateFlow<RoutineEditUiState> = _uiState.asStateFlow()
+        private val _uiState = MutableStateFlow<RoutineCreateUiState>(RoutineCreateUiState.Loading)
+        val uiState: StateFlow<RoutineCreateUiState> = _uiState.asStateFlow()
+
         private val _navigateTo = MutableSharedFlow<NavEvent>()
         val navigateTo = _navigateTo.asSharedFlow()
+
+        fun create() {
+            if (uiState.value is RoutineCreateUiState.Done) return
+            viewModelScope.launch {
+                try {
+                    val newRoutine = Routine(name = "", tasks = emptyList())
+
+                    val routineId = newRoutine.id
+
+                    routineRepository.insertRoutine(newRoutine)
+
+                    routineRepository.getRoutine(routineId).collect { value ->
+                        val routine = value.getOrNull()
+                        if (routine != null) {
+                            _uiState.update {
+                                RoutineCreateUiState.Done(routine)
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    _uiState.update {
+                        RoutineCreateUiState.Error(e)
+                    }
+                }
+            }
+        }
 
         fun fetch(routineId: String) {
             viewModelScope.launch {
@@ -35,13 +63,13 @@ class RoutineEditViewModel
                         val routine = value.getOrNull()
                         if (routine != null) {
                             _uiState.update {
-                                RoutineEditUiState.Done(routine)
+                                RoutineCreateUiState.Done(routine)
                             }
                         }
                     }
                 } catch (e: Exception) {
                     _uiState.update {
-                        RoutineEditUiState.Error(e)
+                        RoutineCreateUiState.Error(e)
                     }
                 }
             }
@@ -49,50 +77,47 @@ class RoutineEditViewModel
 
         fun onRoutineTitleChange(title: String) {
             val state = uiState.value
-            if (state !is RoutineEditUiState.Done) return
+            if (state !is RoutineCreateUiState.Done) return
             viewModelScope.launch {
                 routineRepository.updateRoutine(state.routine.copy(name = title))
             }
         }
 
         fun onClickAddTaskButton() {
+            val state = uiState.value
+            if (state !is RoutineCreateUiState.Done) return
             viewModelScope.launch {
-                if (uiState.value is RoutineEditUiState.Done) {
-                    val routineId = (uiState.value as RoutineEditUiState.Done).routine.id
+                if (uiState.value is RoutineCreateUiState.Done) {
+                    val routineId = state.routine.id
                     _navigateTo.emit(NavEvent.NavigateTo(route = Route.TaskCreate(routineId)))
                 }
             }
         }
 
         fun onClickTaskCard(taskId: String) {
+            val state = uiState.value
+            if (state !is RoutineCreateUiState.Done) return
+            val parentRoutineId = state.routine.id
             viewModelScope.launch {
-                val parentRoutineId = (uiState.value as RoutineEditUiState.Done).routine.id
                 _navigateTo.emit(NavEvent.NavigateTo(route = Route.TaskEdit(parentRoutineId, taskId)))
             }
         }
 
-        fun onBackScreen() {
+        fun onClickBackButton() {
             val state = uiState.value
             viewModelScope.launch {
                 try {
-                    if (state is RoutineEditUiState.Done) {
-                        deleteInvalidTasks()
-                        routineRepository.updateRoutine(state.routine)
+                    if (state is RoutineCreateUiState.Done) {
+                        if (state.routine.name.isBlank()) {
+                            routineRepository.deleteRoutineById(state.routine.id)
+                        } else {
+                            routineRepository.updateRoutine(state.routine)
+                        }
                     }
                 } catch (e: Exception) {
-                    Log.e("RoutineEditViewModel", "Failed to persist routine on back", e)
+                    Log.e("RoutineCreateViewModel", "Failed to persist routine on back", e)
                 } finally {
                     _navigateTo.emit(NavEvent.NavigateBack)
-                }
-            }
-        }
-
-        private suspend fun deleteInvalidTasks() {
-            val state = uiState.value
-            if (state !is RoutineEditUiState.Done) return
-            state.routine.tasks.forEach { task ->
-                if (task.isInvalidValue) {
-                    routineRepository.deleteTaskById(task.id)
                 }
             }
         }

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditScreen.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditScreen.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.routineCreate
+package jp.itIsNoMatter.routineTimerClone.ui.routineedit
 
 import android.util.Log
 import androidx.activity.compose.BackHandler
@@ -12,12 +12,13 @@ import jp.itIsNoMatter.routineTimerClone.ui.components.RoutineEditContent
 import jp.itIsNoMatter.routineTimerClone.ui.navigation.NavEvent
 
 @Composable
-fun RoutineCreateScreen(
+fun RoutineEditScreen(
+    routineId: String,
     navHostController: NavHostController,
-    viewModel: RoutineCreateViewModel = hiltViewModel(),
+    viewModel: RoutineEditViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(Unit) {
-        viewModel.create()
+        viewModel.fetch(routineId)
     }
     LaunchedEffect(Unit) {
         viewModel.navigateTo.collect { event ->
@@ -27,23 +28,24 @@ fun RoutineCreateScreen(
             }
         }
     }
+
     when (val uiState = viewModel.uiState.collectAsState().value) {
-        is RoutineCreateUiState.Loading -> {
+        is RoutineEditUiState.Loading -> {
             Text("Loading ...")
         }
-        is RoutineCreateUiState.Done -> {
-            BackHandler(onBack = viewModel::onClickBackButton)
+        is RoutineEditUiState.Done -> {
+            BackHandler(onBack = viewModel::onBackScreen)
             val doneRoutine = uiState.routine
             RoutineEditContent(
                 routine = doneRoutine,
                 onRoutineTitleChange = viewModel::onRoutineTitleChange,
                 onClickAddButton = viewModel::onClickAddTaskButton,
                 onClickTaskCard = viewModel::onClickTaskCard,
-                onClickBackButton = viewModel::onClickBackButton,
+                onClickBackButton = viewModel::onBackScreen,
             )
         }
-        is RoutineCreateUiState.Error -> {
-            Log.e("RoutineCreateScreen", "Error: ${uiState.e}")
+        is RoutineEditUiState.Error -> {
+            Log.e("RoutineEditScreen", "Error: ${uiState.e}")
         }
     }
 }

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditUiState.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditUiState.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.routineEdit
+package jp.itIsNoMatter.routineTimerClone.ui.routineedit
 
 import jp.itIsNoMatter.routineTimerClone.domain.model.Routine
 

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditViewModel.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditViewModel.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.routineCreate
+package jp.itIsNoMatter.routineTimerClone.ui.routineedit
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.itIsNoMatter.routineTimerClone.core.getOrNull
 import jp.itIsNoMatter.routineTimerClone.data.repository.RoutineRepository
-import jp.itIsNoMatter.routineTimerClone.domain.model.Routine
 import jp.itIsNoMatter.routineTimerClone.ui.navigation.NavEvent
 import jp.itIsNoMatter.routineTimerClone.ui.navigation.Route
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -19,42 +18,15 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class RoutineCreateViewModel
+class RoutineEditViewModel
     @Inject
     constructor(
         private val routineRepository: RoutineRepository,
     ) : ViewModel() {
-        private val _uiState = MutableStateFlow<RoutineCreateUiState>(RoutineCreateUiState.Loading)
-        val uiState: StateFlow<RoutineCreateUiState> = _uiState.asStateFlow()
-
+        private val _uiState = MutableStateFlow<RoutineEditUiState>(RoutineEditUiState.Loading)
+        val uiState: StateFlow<RoutineEditUiState> = _uiState.asStateFlow()
         private val _navigateTo = MutableSharedFlow<NavEvent>()
         val navigateTo = _navigateTo.asSharedFlow()
-
-        fun create() {
-            if (uiState.value is RoutineCreateUiState.Done) return
-            viewModelScope.launch {
-                try {
-                    val newRoutine = Routine(name = "", tasks = emptyList())
-
-                    val routineId = newRoutine.id
-
-                    routineRepository.insertRoutine(newRoutine)
-
-                    routineRepository.getRoutine(routineId).collect { value ->
-                        val routine = value.getOrNull()
-                        if (routine != null) {
-                            _uiState.update {
-                                RoutineCreateUiState.Done(routine)
-                            }
-                        }
-                    }
-                } catch (e: Exception) {
-                    _uiState.update {
-                        RoutineCreateUiState.Error(e)
-                    }
-                }
-            }
-        }
 
         fun fetch(routineId: String) {
             viewModelScope.launch {
@@ -63,13 +35,13 @@ class RoutineCreateViewModel
                         val routine = value.getOrNull()
                         if (routine != null) {
                             _uiState.update {
-                                RoutineCreateUiState.Done(routine)
+                                RoutineEditUiState.Done(routine)
                             }
                         }
                     }
                 } catch (e: Exception) {
                     _uiState.update {
-                        RoutineCreateUiState.Error(e)
+                        RoutineEditUiState.Error(e)
                     }
                 }
             }
@@ -77,47 +49,50 @@ class RoutineCreateViewModel
 
         fun onRoutineTitleChange(title: String) {
             val state = uiState.value
-            if (state !is RoutineCreateUiState.Done) return
+            if (state !is RoutineEditUiState.Done) return
             viewModelScope.launch {
                 routineRepository.updateRoutine(state.routine.copy(name = title))
             }
         }
 
         fun onClickAddTaskButton() {
-            val state = uiState.value
-            if (state !is RoutineCreateUiState.Done) return
             viewModelScope.launch {
-                if (uiState.value is RoutineCreateUiState.Done) {
-                    val routineId = state.routine.id
+                if (uiState.value is RoutineEditUiState.Done) {
+                    val routineId = (uiState.value as RoutineEditUiState.Done).routine.id
                     _navigateTo.emit(NavEvent.NavigateTo(route = Route.TaskCreate(routineId)))
                 }
             }
         }
 
         fun onClickTaskCard(taskId: String) {
-            val state = uiState.value
-            if (state !is RoutineCreateUiState.Done) return
-            val parentRoutineId = state.routine.id
             viewModelScope.launch {
+                val parentRoutineId = (uiState.value as RoutineEditUiState.Done).routine.id
                 _navigateTo.emit(NavEvent.NavigateTo(route = Route.TaskEdit(parentRoutineId, taskId)))
             }
         }
 
-        fun onClickBackButton() {
+        fun onBackScreen() {
             val state = uiState.value
             viewModelScope.launch {
                 try {
-                    if (state is RoutineCreateUiState.Done) {
-                        if (state.routine.name.isBlank()) {
-                            routineRepository.deleteRoutineById(state.routine.id)
-                        } else {
-                            routineRepository.updateRoutine(state.routine)
-                        }
+                    if (state is RoutineEditUiState.Done) {
+                        deleteInvalidTasks()
+                        routineRepository.updateRoutine(state.routine)
                     }
                 } catch (e: Exception) {
-                    Log.e("RoutineCreateViewModel", "Failed to persist routine on back", e)
+                    Log.e("RoutineEditViewModel", "Failed to persist routine on back", e)
                 } finally {
                     _navigateTo.emit(NavEvent.NavigateBack)
+                }
+            }
+        }
+
+        private suspend fun deleteInvalidTasks() {
+            val state = uiState.value
+            if (state !is RoutineEditUiState.Done) return
+            state.routine.tasks.forEach { task ->
+                if (task.isInvalidValue) {
+                    routineRepository.deleteTaskById(task.id)
                 }
             }
         }

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinelist/RoutineListScreen.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinelist/RoutineListScreen.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.routineList
+package jp.itIsNoMatter.routineTimerClone.ui.routinelist
 
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinelist/RoutineListUiAction.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinelist/RoutineListUiAction.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.routineList
+package jp.itIsNoMatter.routineTimerClone.ui.routinelist
 
 import jp.itIsNoMatter.routineTimerClone.domain.model.Routine
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinelist/RoutineListUiState.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinelist/RoutineListUiState.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.routineList
+package jp.itIsNoMatter.routineTimerClone.ui.routinelist
 
 import jp.itIsNoMatter.routineTimerClone.domain.model.Routine
 

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinelist/RoutineListViewModel.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routinelist/RoutineListViewModel.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.routineList
+package jp.itIsNoMatter.routineTimerClone.ui.routinelist
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/runroutine/RunRoutineScreen.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/runroutine/RunRoutineScreen.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.runRoutine
+package jp.itIsNoMatter.routineTimerClone.ui.runroutine
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/runroutine/RunRoutineUiState.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/runroutine/RunRoutineUiState.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.runRoutine
+package jp.itIsNoMatter.routineTimerClone.ui.runroutine
 
 import jp.itIsNoMatter.routineTimerClone.core.LoadedValue
 import jp.itIsNoMatter.routineTimerClone.domain.model.Routine

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/runroutine/RunRoutineViewModel.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/runroutine/RunRoutineViewModel.kt
@@ -1,4 +1,4 @@
-package jp.itIsNoMatter.routineTimerClone.ui.runRoutine
+package jp.itIsNoMatter.routineTimerClone.ui.runroutine
 
 import android.app.Application
 import android.media.SoundPool


### PR DESCRIPTION
## 概要
`ui`配下のpackage名をKotlinの命名規約に沿った形に統一します。

## 変更内容
- `routineCreate` / `routineEdit` / `routineList` / `runRoutine` を全て小文字連結(`routinecreate`等)にリネーム
- リネームに伴い、参照箇所(`EEffortNavGraph.kt`等)のimportを更新

## 動作確認
`./gradlew clean ktlintCheck testDebugUnitTest` を実行し、全て成功することを確認しました。

## Close対象
close #110

## 補足
issue本文では「アンダースコア区切り」への変更を求めていましたが、実装時にこのリポジトリのktlint標準ルール(パッケージ名にアンダースコアを含めることを禁止するルールで、Kotlin公式コーディング規約とも一致)と矛盾することが判明しました。issue作成者(リポジトリオーナー)と相談の上、「全て小文字連結」の命名方針に変更しています。
