### PR TITLE
アプリ名を正式名称eEffortに変更

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">RoutineTimerClone</string>
+    <string name="app_name">eEffort</string>
     <string name="routine_edit_title_place_holder">ルーチン名を入力</string>
     <string name="routine_create_title_place_holder">ルーチン名を入力</string>
 


### PR DESCRIPTION
## 概要
アプリ名を開発用の仮名から、アプリ内で既に使用している正式名称に変更します。

## 変更内容
- `strings.xml`の`app_name`を`RoutineTimerClone`から`eEffort`に変更(RoutineList画面のTopAppBarタイトル等と統一)

## 動作確認
`./gradlew clean assembleDebug ktlintCheck` を実行し、ビルドが成功することを確認しました。

## Close対象
close #67

## 補足
特になし
