### PR TITLE
Taskの所要時間を発話形式にフォーマットするヘルパーメソッドを追加

### DIFF
--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/domain/model/Task.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/domain/model/Task.kt
@@ -36,6 +36,8 @@ data class Task(
     val isInvalidValue: Boolean
         get() = name.isEmpty() || duration == Duration.Zero
 
+    fun toSpokenDurationString(): String = "${minutes}分${seconds}秒"
+
     companion object {
         val Empty =
             Task(

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/runRoutine/RunRoutineViewModel.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/runRoutine/RunRoutineViewModel.kt
@@ -113,7 +113,7 @@ class RunRoutineViewModel
         }
 
         fun speakTaskInstruction(task: Task) {
-            speak("今から${task.minutes}分${task.seconds}秒間、${task.name}を始めてください")
+            speak("今から${task.toSpokenDurationString()}間、${task.name}を始めてください")
         }
 
         override fun onCleared() {

--- a/app/src/test/java/jp/itIsNoMatter/routineTimerClone/domain/TaskTest.kt
+++ b/app/src/test/java/jp/itIsNoMatter/routineTimerClone/domain/TaskTest.kt
@@ -24,4 +24,16 @@ class TaskTest {
         assertEquals(1, task.minutes)
         assertEquals(30, task.seconds)
     }
+
+    @Test
+    fun toSpokenDurationStringTest() {
+        val task = Task(id = "1", name = "hoge", minutes = 2, seconds = 30, announceRemainingTimeFlag = true)
+        assertEquals("2分30秒", task.toSpokenDurationString())
+    }
+
+    @Test
+    fun toSpokenDurationStringTest_singleDigitSeconds() {
+        val task = Task(id = "1", name = "hoge", minutes = 0, seconds = 5, announceRemainingTimeFlag = true)
+        assertEquals("0分5秒", task.toSpokenDurationString())
+    }
 }


### PR DESCRIPTION
## 概要
Taskの所要時間を発話形式の文字列に変換するヘルパーメソッドを追加します。

## 変更内容
- `Task.toSpokenDurationString()`を追加(例: `minutes=2, seconds=30` → `"2分30秒"`)
- 単体テストを2件追加(通常ケース、秒が一桁のケース)
- `RunRoutineViewModel.speakTaskInstruction()`内の重複していたフォーマットロジックを新メソッドに置き換え

## 動作確認
`./gradlew clean ktlintCheck testDebugUnitTest` を実行し、新規テストを含め全て成功することを確認しました。

## Close対象
close #65

## 補足
特になし
