### PR TITLE
ルーチン編集画面: タイトル未入力時に戻る操作を無効化しUIテストを追加

### DIFF
--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/components/RoutineEditContent.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/components/RoutineEditContent.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
@@ -46,10 +47,13 @@ import jp.itIsNoMatter.routineTimerClone.domain.model.Duration
 import jp.itIsNoMatter.routineTimerClone.domain.model.Routine
 import jp.itIsNoMatter.routineTimerClone.domain.model.Task
 
+internal const val ROUTINE_TITLE_TEXT_FIELD_TEST_TAG = "routineTitleTextField"
+
 @Composable
 fun RoutineEditContent(
     routine: Routine,
     isSaving: Boolean = false,
+    isBackButtonEnabled: Boolean = !isSaving,
     onRoutineTitleChange: (String) -> Unit = {},
     onClickAddButton: () -> Unit = {},
     onClickTaskCard: (taskId: String) -> Unit = {},
@@ -62,7 +66,7 @@ fun RoutineEditContent(
                     routine = routine,
                     onRoutineTitleChange = onRoutineTitleChange,
                     onClickBackButton = onClickBackButton,
-                    enabled = !isSaving,
+                    enabled = isBackButtonEnabled,
                 )
             },
             floatingActionButton = {
@@ -158,7 +162,7 @@ fun RoutineEditTopBar(
                     onClickBackButton()
                 },
             ) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
             }
             Box(modifier = Modifier.weight(1f)) {
                 if (routine.name.isEmpty()) {
@@ -187,7 +191,8 @@ fun RoutineEditTopBar(
                         ),
                     modifier =
                         Modifier
-                            .fillMaxWidth(),
+                            .fillMaxWidth()
+                            .testTag(ROUTINE_TITLE_TEXT_FIELD_TEST_TAG),
                 )
             }
         }

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditScreen.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditScreen.kt
@@ -39,6 +39,7 @@ fun RoutineEditScreen(
             RoutineEditContent(
                 routine = doneRoutine,
                 isSaving = uiState.isSaving,
+                isBackButtonEnabled = !uiState.isSaving && doneRoutine.name.isNotBlank(),
                 onRoutineTitleChange = viewModel::onRoutineTitleChange,
                 onClickAddButton = viewModel::onClickAddTaskButton,
                 onClickTaskCard = viewModel::onClickTaskCard,
@@ -47,6 +48,7 @@ fun RoutineEditScreen(
         }
         is RoutineEditUiState.Error -> {
             Log.e("RoutineEditScreen", "Error: ${uiState.e}")
+            Text("Error")
         }
     }
 }

--- a/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditViewModel.kt
+++ b/app/src/main/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditViewModel.kt
@@ -74,7 +74,7 @@ class RoutineEditViewModel
 
         fun onBackScreen() {
             val state = uiState.value
-            if (state is RoutineEditUiState.Done && state.isSaving) return
+            if (state is RoutineEditUiState.Done && (state.isSaving || state.routine.name.isBlank())) return
             viewModelScope.launch {
                 try {
                     if (state is RoutineEditUiState.Done) {

--- a/app/src/test/java/jp/itIsNoMatter/routineTimerClone/ui/components/RoutineEditContentTest.kt
+++ b/app/src/test/java/jp/itIsNoMatter/routineTimerClone/ui/components/RoutineEditContentTest.kt
@@ -1,0 +1,127 @@
+package jp.itIsNoMatter.routineTimerClone.ui.components
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import io.mockk.mockk
+import io.mockk.verify
+import jp.itIsNoMatter.routineTimerClone.domain.model.Duration
+import jp.itIsNoMatter.routineTimerClone.domain.model.Routine
+import jp.itIsNoMatter.routineTimerClone.domain.model.Task
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h891dp")
+class RoutineEditContentTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val routine =
+        Routine(
+            id = "routine-1",
+            name = "test routine",
+            tasks =
+                listOf(
+                    Task(id = "task-1", name = "task A", duration = Duration(1, 2), announceRemainingTimeFlag = true),
+                    Task(id = "task-2", name = "task B", duration = Duration(3, 15), announceRemainingTimeFlag = true),
+                ),
+        )
+
+    @Test
+    fun `初期表示 - ルーチン名・各タスク名時間・合計時間が表示されること`() {
+        composeTestRule.setContent {
+            RoutineEditContent(routine = routine)
+        }
+
+        composeTestRule.onNodeWithText(routine.name).assertExists()
+        routine.tasks.forEach { task ->
+            composeTestRule.onNodeWithText(task.name).assertExists()
+            composeTestRule.onNodeWithText(task.duration.toDisplayString()).assertExists()
+        }
+        composeTestRule.onNodeWithText("計 " + routine.getTotalDuration().toDisplayString()).assertExists()
+    }
+
+    @Test
+    fun `FABタップでonClickAddButtonが呼ばれること`() {
+        val onClickAddButton = mockk<() -> Unit>(relaxed = true)
+        composeTestRule.setContent {
+            RoutineEditContent(routine = routine, onClickAddButton = onClickAddButton)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Add Task").performClick()
+
+        verify { onClickAddButton() }
+    }
+
+    @Test
+    fun `戻るボタンタップでonClickBackButtonが呼ばれること`() {
+        val onClickBackButton = mockk<() -> Unit>(relaxed = true)
+        composeTestRule.setContent {
+            RoutineEditContent(routine = routine, onClickBackButton = onClickBackButton)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
+
+        verify { onClickBackButton() }
+    }
+
+    @Test
+    fun `タスクカードタップでonClickTaskCardがそのタスクのidで呼ばれること`() {
+        val onClickTaskCard = mockk<(String) -> Unit>(relaxed = true)
+        composeTestRule.setContent {
+            RoutineEditContent(routine = routine, onClickTaskCard = onClickTaskCard)
+        }
+
+        composeTestRule.onNodeWithText(routine.tasks[1].name).performClick()
+
+        verify { onClickTaskCard(routine.tasks[1].id) }
+    }
+
+    @Test
+    fun `タイトル入力でonRoutineTitleChangeが呼ばれること`() {
+        val onRoutineTitleChange = mockk<(String) -> Unit>(relaxed = true)
+        composeTestRule.setContent {
+            RoutineEditContent(routine = routine, onRoutineTitleChange = onRoutineTitleChange)
+        }
+
+        composeTestRule.onNodeWithTag(ROUTINE_TITLE_TEXT_FIELD_TEST_TAG).performTextInput("!")
+
+        verify { onRoutineTitleChange(routine.name + "!") }
+    }
+
+    @Test
+    fun `isBackButtonEnabledがfalseのとき戻るボタンが無効化されること`() {
+        composeTestRule.setContent {
+            RoutineEditContent(routine = routine, isBackButtonEnabled = false)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Back").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `isBackButtonEnabled未指定時はisSavingの否定がデフォルトになること`() {
+        composeTestRule.setContent {
+            RoutineEditContent(routine = routine, isSaving = true)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Back").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `isBackButtonEnabled未指定かつisSavingがfalseのとき戻るボタンが有効であること`() {
+        composeTestRule.setContent {
+            RoutineEditContent(routine = routine, isSaving = false)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Back").assertIsEnabled()
+    }
+}

--- a/app/src/test/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditScreenTest.kt
+++ b/app/src/test/java/jp/itIsNoMatter/routineTimerClone/ui/routineedit/RoutineEditScreenTest.kt
@@ -1,0 +1,148 @@
+package jp.itIsNoMatter.routineTimerClone.ui.routineedit
+
+import android.util.Log
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.navigation.NavHostController
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import jp.itIsNoMatter.routineTimerClone.core.LoadedValue
+import jp.itIsNoMatter.routineTimerClone.data.repository.RoutineRepository
+import jp.itIsNoMatter.routineTimerClone.domain.model.Duration
+import jp.itIsNoMatter.routineTimerClone.domain.model.Routine
+import jp.itIsNoMatter.routineTimerClone.domain.model.Task
+import jp.itIsNoMatter.routineTimerClone.ui.navigation.Route
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "w411dp-h891dp")
+class RoutineEditScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val routineRepository = mockk<RoutineRepository>()
+    private val navHostController = mockk<NavHostController>(relaxed = true)
+
+    private val routine =
+        Routine(
+            id = "routine-1",
+            name = "test",
+            tasks =
+                listOf(
+                    Task(id = "task-1", name = "task A", duration = Duration(1, 0), announceRemainingTimeFlag = true),
+                ),
+        )
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic(Log::class)
+        every { Log.e(any(), any()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+        Dispatchers.resetMain()
+    }
+
+    private fun setContent(routineToLoad: Routine): RoutineEditViewModel {
+        every { routineRepository.getRoutine(routineToLoad.id) } returns flowOf(LoadedValue.Done(routineToLoad))
+        val viewModel = RoutineEditViewModel(routineRepository)
+        composeTestRule.setContent {
+            RoutineEditScreen(routineId = routineToLoad.id, navHostController = navHostController, viewModel = viewModel)
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.waitForIdle()
+        return viewModel
+    }
+
+    @Test
+    fun `タイトルが空のとき戻るボタンが無効化され、タップしても保存・画面遷移が起きないこと`() {
+        setContent(routine.copy(name = ""))
+
+        composeTestRule.onNodeWithContentDescription("Back").assertIsNotEnabled()
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.waitForIdle()
+
+        coVerify(exactly = 0) { routineRepository.updateRoutine(any()) }
+        verify(exactly = 0) { navHostController.popBackStack() }
+    }
+
+    @Test
+    fun `タスク追加ボタンタップでタスク作成画面への遷移が呼ばれること`() {
+        setContent(routine)
+
+        composeTestRule.onNodeWithContentDescription("Add Task").performClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.waitForIdle()
+
+        verify { navHostController.navigate(Route.TaskCreate(routine.id)) }
+    }
+
+    @Test
+    fun `タスクカードタップでタスク編集画面への遷移が呼ばれること`() {
+        setContent(routine)
+
+        composeTestRule.onNodeWithText(routine.tasks[0].name).performClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.waitForIdle()
+
+        verify { navHostController.navigate(Route.TaskEdit(routine.id, routine.tasks[0].id)) }
+    }
+
+    @Test
+    fun `戻るボタンタップでupdateRoutineが呼ばれpopBackStackされること`() {
+        coEvery { routineRepository.updateRoutine(routine) } just Runs
+
+        setContent(routine)
+
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.waitForIdle()
+
+        coVerify { routineRepository.updateRoutine(routine) }
+        verify { navHostController.popBackStack() }
+    }
+
+    @Test
+    fun `エラー状態のときErrorのTextが表示されること`() {
+        every { routineRepository.getRoutine(routine.id) } returns flow { throw RuntimeException("network error") }
+
+        val viewModel = RoutineEditViewModel(routineRepository)
+        composeTestRule.setContent {
+            RoutineEditScreen(routineId = routine.id, navHostController = navHostController, viewModel = viewModel)
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Error").assertExists()
+    }
+}


### PR DESCRIPTION
## 概要
ルーチン編集画面のUIテスト(Compose/Robolectric)を追加し、タイトル未入力時に戻る操作(保存)ができてしまう問題を修正する。

## 変更内容
- `RoutineEditContent`に`isBackButtonEnabled`パラメータを追加し、戻るボタンの活性/非活性を呼び出し元から制御可能にする
- `RoutineEditScreen`で`isBackButtonEnabled = !uiState.isSaving && doneRoutine.name.isNotBlank()`を指定し、タイトルが空の間は戻るボタンを無効化
- `RoutineEditViewModel.onBackScreen()`にタイトル空チェックを追加し、無効化をすり抜けても保存・画面遷移が起きないようガード
- 戻るボタンのアイコンに`contentDescription = "Back"`を付与、タイトル入力欄に`testTag`を付与(いずれもテストからの参照用)
- エラー状態時に"Error"のTextを表示するよう追加
- `RoutineEditContentTest`(初期表示、FAB/戻る/タスクカードタップ、タイトル入力、`isBackButtonEnabled`の各パターン)を追加
- `RoutineEditScreenTest`(タイトル空時の戻る操作無効化、タスク追加/編集への画面遷移、戻る操作での保存・popBackStack、エラー表示)を追加

## 動作確認
`./gradlew :app:testDebugUnitTest --tests "jp.itIsNoMatter.routineTimerClone.ui.components.RoutineEditContentTest" --tests "jp.itIsNoMatter.routineTimerClone.ui.routineedit.RoutineEditScreenTest"` を実行し、追加した全テストが成功することを確認済み(BUILD SUCCESSFUL)。

## Close対象
close #51

## 補足
特になし
