### PR TITLE
危険なasキャストの判定ロジックを実装しAsCastCheckerに組み込む

### DIFF
--- a/fir-checker-poc-sample/src/main/kotlin/DangerConditionsSample.kt
+++ b/fir-checker-poc-sample/src/main/kotlin/DangerConditionsSample.kt
@@ -1,0 +1,23 @@
+package jp.itisnomatter.firchecker.sample
+
+sealed interface Animal
+class Dog : Animal
+class Cat : Animal
+
+fun describe(animal: Animal): String {
+    // 宣言型 Animal がキャスト先 Animal を満たすアップキャスト(実質同一型)。失敗しようがないため安全。
+    // AsCastChecker によるコンパイルエラーは発生しない想定。
+    val asAnimal: Animal = animal as Animal
+
+    if (animal is Dog) {
+        // スマートキャストで既に Dog に絞り込まれているため、この as は不要(代替可能)。
+        // AsCastChecker によりコンパイルエラーになる想定。
+        val dog = animal as Dog
+        return "Dog: $dog, $asAnimal"
+    }
+
+    // 宣言型・スマートキャストのいずれからも Cat であることは保証されないダウンキャスト。
+    // AsCastChecker によりコンパイルエラーになる想定。
+    val cat = animal as Cat
+    return "Cat: $cat"
+}

--- a/fir-checker-poc/README.md
+++ b/fir-checker-poc/README.md
@@ -1,7 +1,8 @@
-# FIR Checker PoC (#154)
+# FIR Checker PoC (#154) / 危険判定ロジック (#155)
 
-K2コンパイラのFIR拡張APIを使い、危険な`as`キャストを検出してコンパイルエラーにする最小構成のコンパイラプラグインのPoC。
-`#153`(FIR Checker導入)の技術調査タスク。**本モジュールは`:app`のビルドには一切組み込まれておらず、独立した検証用モジュール。**
+K2コンパイラのFIR拡張APIを使い、危険な`as`キャストを検出してコンパイルエラーにする最小構成のコンパイラプラグインのPoC(#154)と、
+「危険」とみなす条件を定義した検出ロジック本体(#155)。
+`#153`(FIR Checker導入)の子issue。**本モジュールは`:app`のビルドには一切組み込まれておらず、独立した検証用モジュール。**
 
 ## 構成
 
@@ -14,14 +15,15 @@ K2コンパイラのFIR拡張APIを使い、危険な`as`キャストを検出�
 ./gradlew :fir-checker-poc-sample:compileKotlin
 ```
 
-`fir-checker-poc-sample/src/main/kotlin/Sample.kt`の`value as String`(危険な`as`)で以下のエラーが出て失敗する。
+`fir-checker-poc-sample/src/main/kotlin/Sample.kt`の`value as String`(宣言型・スマートキャストいずれからも保証されないダウンキャスト)で以下のエラーが出て失敗する。
 `value as? Int`(安全な`as?`)は検出対象外のため、そちらではエラーが出ないことも確認済み。
 
 ```
-e: .../Sample.kt:5:16 Unsafe 'as' cast is prohibited by AsCastChecker. Use 'as?' or a smart cast instead.
+e: .../Sample.kt:5:16 This 'as' downcast is not guaranteed to succeed and may throw ClassCastException at runtime. Use 'as?' or an 'is' check instead.
 ```
 
 `as`を`as?`に変えれば`BUILD SUCCESSFUL`になることも確認済み。
+`DangerConditionsSample.kt`では残り2つの条件(アップキャストは安全/スマートキャストで代替可能)も確認済み(詳細は次節)。
 
 ## FIR拡張APIの調査結果
 
@@ -40,10 +42,27 @@ e: .../Sample.kt:5:16 Unsafe 'as' cast is prohibited by AsCastChecker. Use 'as?'
 4. **チェッカー本体**
    `as`/`as?`/`is`/`!is`はいずれもFIR上では`FirTypeOperatorCall`という同じノードで表現され、`FirOperation`列挙型(`AS`, `SAFE_AS`, `IS`, `NOT_IS`)で区別される。
    対応する基底クラスは`FirTypeOperatorCallChecker`で、`ExpressionCheckers.typeOperatorCallCheckers`に登録する。
-   今回のPoCでは`expression.operation == FirOperation.AS`の場合に無条件でエラーを出す(スマートキャストで代替可能かどうか等の判定は行わない、issueの要求通りの最小構成)。この判定ロジックの精緻化は`#155`のスコープ。
+   `#154`のPoCでは`expression.operation == FirOperation.AS`の場合に無条件でエラーを出していた(issueの要求通りの最小構成)。「危険」の判定ロジックへの精緻化は`#155`で行った(後述)。
 
 5. **診断(エラー)の定義**
    `by error0<PsiElement>()`という委譲プロパティでエラーファクトリを定義し(`org.jetbrains.kotlin.diagnostics.error0`)、`BaseDiagnosticRendererFactory`でメッセージ文言を紐付け、`RootDiagnosticRendererFactory.registerFactory(...)`でグローバル登録する。
+
+## 「危険」の判定ロジック (#155)
+
+`#154`のPoCは`as`を無条件でエラーにしていたが、実際にはキャストが失敗しようがない安全なケース(アップキャスト等)まで巻き込んでしまう。
+`AsCastChecker`は以下の2つの型情報を`ConeKotlinType`の`isSubtypeOf`(`org.jetbrains.kotlin.fir.types.isSubtypeOf`)で比較し、`AsCastDangerClassifier`(純粋関数、`fir-checker-poc/src/test`でユニットテスト済み)に渡して3値に分類する。
+
+- **宣言型 (`declaredType`)**: スマートキャストを考慮しない、素の型。`argument`が`FirSmartCastExpression`でラップされている場合は`originalExpression.resolvedType`、そうでなければ`argument.resolvedType`をそのまま使う。
+- **スマートキャスト型 (`smartCastType`)**: `FirSmartCastExpression.smartcastType`。スマートキャストが効いていない場合は`null`。
+
+| 条件 | 分類 | 意味 |
+| --- | --- | --- |
+| `declaredType`がキャスト先のサブタイプ(または同一型) | `SAFE` | アップキャスト/同一型キャスト。失敗しようがない |
+| `declaredType`は満たさないが`smartCastType`がキャスト先のサブタイプ | `SMART_CAST_REPLACEABLE` | issueの「スマートキャストで代替可能」に対応。`as`を書かずスマートキャストされた値をそのまま使うべき |
+| どちらも満たさない | `UNGUARANTEED_DOWNCAST` | issueの「型の関係が保証されないダウンキャストである」に対応。`ClassCastException`の恐れがある実行時失敗しうるダウンキャスト |
+
+`SAFE`以外は`AsCastFirErrors`の対応する診断(`SMART_CAST_REPLACEABLE_AS_CAST` / `UNGUARANTEED_DOWNCAST_AS_CAST`)でコンパイルエラーにする。
+`fir-checker-poc-sample/src/main/kotlin/DangerConditionsSample.kt`で3パターンとも`./gradlew :fir-checker-poc-sample:compileKotlin`でローカル確認済み(アップキャストの行だけエラーが出ないことも確認済み)。
 
 ### Gradle組み込み(プラグインとしての適用方法)
 

--- a/fir-checker-poc/build.gradle.kts
+++ b/fir-checker-poc/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     implementation(libs.kotlin.compiler.embeddable)
+    testImplementation(libs.junit)
 }

--- a/fir-checker-poc/src/main/kotlin/jp/itisnomatter/firchecker/AsCastChecker.kt
+++ b/fir-checker-poc/src/main/kotlin/jp/itisnomatter/firchecker/AsCastChecker.kt
@@ -6,11 +6,38 @@ import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirTypeOperatorCallChecker
 import org.jetbrains.kotlin.fir.expressions.FirOperation
+import org.jetbrains.kotlin.fir.expressions.FirSmartCastExpression
 import org.jetbrains.kotlin.fir.expressions.FirTypeOperatorCall
+import org.jetbrains.kotlin.fir.expressions.argument
+import org.jetbrains.kotlin.fir.types.coneType
+import org.jetbrains.kotlin.fir.types.isSubtypeOf
+import org.jetbrains.kotlin.fir.types.resolvedType
 
 object AsCastChecker : FirTypeOperatorCallChecker(MppCheckerKind.Common) {
     override fun check(expression: FirTypeOperatorCall, context: CheckerContext, reporter: DiagnosticReporter) {
         if (expression.operation != FirOperation.AS) return
-        reporter.reportOn(expression.source, AsCastFirErrors.UNSAFE_AS_CAST, context)
+
+        val session = context.session
+        val argument = expression.argument
+        val targetType = expression.conversionTypeRef.coneType
+
+        // スマートキャスト適用中は argument が FirSmartCastExpression でラップされる。
+        // 素の宣言型(originalExpression)と、スマートキャストで絞り込まれた型を分けて評価する。
+        val smartCastArgument = argument as? FirSmartCastExpression
+        val declaredType = (smartCastArgument?.originalExpression ?: argument).resolvedType
+        val smartCastType = smartCastArgument?.smartcastType?.coneType
+
+        val danger = AsCastDangerClassifier.classify(
+            declaredTypeSatisfiesTarget = declaredType.isSubtypeOf(targetType, session),
+            smartCastTypeSatisfiesTarget = smartCastType?.isSubtypeOf(targetType, session) ?: false,
+        )
+
+        when (danger) {
+            AsCastDanger.SAFE -> Unit
+            AsCastDanger.SMART_CAST_REPLACEABLE ->
+                reporter.reportOn(expression.source, AsCastFirErrors.SMART_CAST_REPLACEABLE_AS_CAST, context)
+            AsCastDanger.UNGUARANTEED_DOWNCAST ->
+                reporter.reportOn(expression.source, AsCastFirErrors.UNGUARANTEED_DOWNCAST_AS_CAST, context)
+        }
     }
 }

--- a/fir-checker-poc/src/main/kotlin/jp/itisnomatter/firchecker/AsCastDangerClassifier.kt
+++ b/fir-checker-poc/src/main/kotlin/jp/itisnomatter/firchecker/AsCastDangerClassifier.kt
@@ -1,0 +1,20 @@
+package jp.itisnomatter.firchecker
+
+enum class AsCastDanger {
+    /** 元の宣言型のままキャスト先に代入可能。アップキャストや同一型へのキャストで、失敗しうる余地がない。 */
+    SAFE,
+
+    /** スマートキャストにより既にキャスト先を満たしている。明示的な `as` は不要で、スマートキャストに委ねられる。 */
+    SMART_CAST_REPLACEABLE,
+
+    /** 宣言型・スマートキャストのいずれからもキャスト先への型関係が保証されない、実行時失敗しうるダウンキャスト。 */
+    UNGUARANTEED_DOWNCAST,
+}
+
+object AsCastDangerClassifier {
+    fun classify(declaredTypeSatisfiesTarget: Boolean, smartCastTypeSatisfiesTarget: Boolean): AsCastDanger = when {
+        declaredTypeSatisfiesTarget -> AsCastDanger.SAFE
+        smartCastTypeSatisfiesTarget -> AsCastDanger.SMART_CAST_REPLACEABLE
+        else -> AsCastDanger.UNGUARANTEED_DOWNCAST
+    }
+}

--- a/fir-checker-poc/src/main/kotlin/jp/itisnomatter/firchecker/AsCastErrorMessages.kt
+++ b/fir-checker-poc/src/main/kotlin/jp/itisnomatter/firchecker/AsCastErrorMessages.kt
@@ -6,8 +6,12 @@ import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 object AsCastErrorMessages : BaseDiagnosticRendererFactory() {
     override val MAP: KtDiagnosticFactoryToRendererMap = KtDiagnosticFactoryToRendererMap("AsCastChecker").apply {
         put(
-            AsCastFirErrors.UNSAFE_AS_CAST,
-            "Unsafe 'as' cast is prohibited by AsCastChecker. Use 'as?' or a smart cast instead.",
+            AsCastFirErrors.SMART_CAST_REPLACEABLE_AS_CAST,
+            "This 'as' cast is redundant: the value is already smart-cast to a compatible type. Remove the cast and rely on the smart cast instead.",
+        )
+        put(
+            AsCastFirErrors.UNGUARANTEED_DOWNCAST_AS_CAST,
+            "This 'as' downcast is not guaranteed to succeed and may throw ClassCastException at runtime. Use 'as?' or an 'is' check instead.",
         )
     }
 }

--- a/fir-checker-poc/src/main/kotlin/jp/itisnomatter/firchecker/AsCastFirErrors.kt
+++ b/fir-checker-poc/src/main/kotlin/jp/itisnomatter/firchecker/AsCastFirErrors.kt
@@ -5,7 +5,8 @@ import org.jetbrains.kotlin.diagnostics.error0
 import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
 
 object AsCastFirErrors {
-    val UNSAFE_AS_CAST by error0<PsiElement>()
+    val SMART_CAST_REPLACEABLE_AS_CAST by error0<PsiElement>()
+    val UNGUARANTEED_DOWNCAST_AS_CAST by error0<PsiElement>()
 
     init {
         RootDiagnosticRendererFactory.registerFactory(AsCastErrorMessages)

--- a/fir-checker-poc/src/test/kotlin/jp/itisnomatter/firchecker/AsCastDangerClassifierTest.kt
+++ b/fir-checker-poc/src/test/kotlin/jp/itisnomatter/firchecker/AsCastDangerClassifierTest.kt
@@ -1,0 +1,47 @@
+package jp.itisnomatter.firchecker
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AsCastDangerClassifierTest {
+
+    @Test
+    fun `declared type already satisfies target -- upcast or identity cast is safe`() {
+        val result = AsCastDangerClassifier.classify(
+            declaredTypeSatisfiesTarget = true,
+            smartCastTypeSatisfiesTarget = false,
+        )
+
+        assertEquals(AsCastDanger.SAFE, result)
+    }
+
+    @Test
+    fun `only smart cast type satisfies target -- redundant, replaceable by smart cast`() {
+        val result = AsCastDangerClassifier.classify(
+            declaredTypeSatisfiesTarget = false,
+            smartCastTypeSatisfiesTarget = true,
+        )
+
+        assertEquals(AsCastDanger.SMART_CAST_REPLACEABLE, result)
+    }
+
+    @Test
+    fun `neither declared nor smart cast type satisfies target -- unguaranteed downcast`() {
+        val result = AsCastDangerClassifier.classify(
+            declaredTypeSatisfiesTarget = false,
+            smartCastTypeSatisfiesTarget = false,
+        )
+
+        assertEquals(AsCastDanger.UNGUARANTEED_DOWNCAST, result)
+    }
+
+    @Test
+    fun `declared type satisfying target takes priority over smart cast flag`() {
+        val result = AsCastDangerClassifier.classify(
+            declaredTypeSatisfiesTarget = true,
+            smartCastTypeSatisfiesTarget = true,
+        )
+
+        assertEquals(AsCastDanger.SAFE, result)
+    }
+}


### PR DESCRIPTION
## 概要
#153の子issue。#154のPoCは任意の`as`キャストを無条件でコンパイルエラーにしていたが、失敗しようがない安全なアップキャストまで巻き込んでしまう課題があった。「危険」とみなす`as`キャストの条件を定義し、`AsCastChecker`に実際の判定ロジックを実装した。

## 変更内容
- `AsCastDangerClassifier`(新規)を追加。宣言型・スマートキャスト型それぞれがキャスト先を満たすかどうかの2つのbooleanから、`SAFE` / `SMART_CAST_REPLACEABLE`(スマートキャストで代替可能) / `UNGUARANTEED_DOWNCAST`(型の関係が保証されないダウンキャスト)の3値に分類する純粋関数
- `AsCastChecker`を変更し、`ConeKotlinType.isSubtypeOf`・`FirExpression.resolvedType`・`FirSmartCastExpression`(originalExpression/smartcastType)を使って上記2つのbooleanを算出し、`SAFE`以外の場合のみ診断を報告するように修正
- `AsCastFirErrors`/`AsCastErrorMessages`: 単一だった`UNSAFE_AS_CAST`診断を、理由ごとに`SMART_CAST_REPLACEABLE_AS_CAST`/`UNGUARANTEED_DOWNCAST_AS_CAST`の2種類に分割し、それぞれ具体的な修正方法を含むメッセージに変更
- `fir-checker-poc-sample/DangerConditionsSample.kt`(新規): アップキャスト(安全)/スマートキャスト代替可能/保証されないダウンキャストの3パターンを含むサンプルを追加
- `fir-checker-poc/build.gradle.kts`: ユニットテスト用に`testImplementation(libs.junit)`を追加
- `fir-checker-poc/README.md`: 「危険」の判定ロジック(3値分類の条件と対応する診断)を追記

## 動作確認
- `./gradlew :fir-checker-poc:test` — `AsCastDangerClassifierTest`の4ケース(SAFE/SMART_CAST_REPLACEABLE/UNGUARANTEED_DOWNCAST/優先順位)すべて成功を確認済み
- `./gradlew :fir-checker-poc-sample:compileKotlin` — 実際にKotlin 2.1.10のFIR上でコンパイルし、以下を確認済み
  - `Sample.kt`の`value as String`(保証されないダウンキャスト)→ エラー、`value as? Int` → エラーなし(既存動作を維持)
  - `DangerConditionsSample.kt`の`animal as Animal`(アップキャスト)→ **エラーなし**(新規で安全と判定されるようになった箇所)
  - `DangerConditionsSample.kt`の`if (animal is Dog) { animal as Dog }` → `SMART_CAST_REPLACEABLE_AS_CAST`でエラー
  - `DangerConditionsSample.kt`の`animal as Cat` → `UNGUARANTEED_DOWNCAST_AS_CAST`でエラー

## Close対象
close #155

## 補足
- 本PRのベースとなる#154(PoC)は作業中にPR #158としてmasterにマージ済みのため、本PRはmasterに対するdiffになっている
- `fir-checker-poc`モジュールは引き続き`:app`のビルド・CIには組み込まれていない独立モジュール(Gradleプラグイン化して組み込むのは#156のスコープ)
