### PR TITLE
FIR Checkerをfirchecker.enabledで切り替え可能な形で:appに組み込む

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,14 @@ android {
     }
 }
 
+// #156: FIR Checker(危険な as キャスト検出, #153)の有効/無効切り替え。詳細は gradle.properties 参照。
+val firCheckerEnabled = (findProperty("firChecker.enabled") as String?)?.toBoolean() ?: false
+
 dependencies {
+    if (firCheckerEnabled) {
+        kotlinCompilerPluginClasspath(project(":fir-checker-poc"))
+    }
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/fir-checker-poc/README.md
+++ b/fir-checker-poc/README.md
@@ -1,8 +1,8 @@
-# FIR Checker PoC (#154) / 危険判定ロジック (#155)
+# FIR Checker PoC (#154) / 危険判定ロジック (#155) / Gradle組み込み (#156)
 
 K2コンパイラのFIR拡張APIを使い、危険な`as`キャストを検出してコンパイルエラーにする最小構成のコンパイラプラグインのPoC(#154)と、
 「危険」とみなす条件を定義した検出ロジック本体(#155)。
-`#153`(FIR Checker導入)の子issue。**本モジュールは`:app`のビルドには一切組み込まれておらず、独立した検証用モジュール。**
+`#153`(FIR Checker導入)の子issue。**`:app`には`firChecker.enabled`(既定`false`)で有効化できる形で組み込み済み(`#156`)。詳細は後述。**
 
 ## 構成
 
@@ -74,7 +74,35 @@ dependencies {
 }
 ```
 
-`#156`(Gradleプラグイン化)では、これをオプション指定(有効/無効切り替え)可能な形でパッケージングし、`:app`に組み込むことになる想定。
+### `:app`への組み込み (#156)
+
+上記の仕組みを`:app`に実際に適用した。ただし現時点の`:app`には`#157`(危険な`as`の棚卸し)未対応の危険なキャストが複数残っており、
+チェッカーを無条件で有効化するとビルドが壊れる。そのため`gradle.properties`の`firChecker.enabled`(既定`false`)でON/OFFを切り替えられる形にした。
+
+```kotlin
+// app/build.gradle.kts
+val firCheckerEnabled = (findProperty("firChecker.enabled") as String?)?.toBoolean() ?: false
+
+dependencies {
+    if (firCheckerEnabled) {
+        kotlinCompilerPluginClasspath(project(":fir-checker-poc"))
+    }
+    // ...
+}
+```
+
+動作確認方法:
+
+```
+# 既定(無効)。既存コードに影響せず BUILD SUCCESSFUL になることを確認済み
+./gradlew :app:compileDebugKotlin
+
+# 有効化。#157 未対応の危険なキャスト6件(RunRoutineViewModel.kt / RoutineEditViewModel.kt)が
+# すべて検出されコンパイルエラーになることを確認済み
+./gradlew :app:compileDebugKotlin -PfirChecker.enabled=true
+```
+
+`#157`で危険なキャストを解消したのち、`firChecker.enabled`の既定値を`true`に切り替える想定。
 
 ## つまずいた点
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# #156: :app に FIR Checker(危険な as キャスト検出, #153)を適用するかどうかのスイッチ。
+# #157(既存コードの as 棚卸し)が完了するまでは既存の危険なキャストでビルドが壊れるため既定で無効。
+# 有効化して確認する場合: ./gradlew :app:compileDebugKotlin -PfirChecker.enabled=true
+firChecker.enabled=false


### PR DESCRIPTION
## 概要
#155で実装したFIR Checker(危険な`as`キャスト検出)を、`gradle.properties`の`firChecker.enabled`プロパティで有効/無効を切り替えられる形で`:app`のGradleビルドに組み込んだ。

## 変更内容
- `gradle.properties`: `firChecker.enabled=false`を追加(既定は無効)
- `app/build.gradle.kts`: `firChecker.enabled`が`true`のときのみ`kotlinCompilerPluginClasspath(project(":fir-checker-poc"))`を追加するよう条件分岐を追加
- `fir-checker-poc/README.md`: `:app`への組み込み内容(#156)を追記し、既定で無効にしている理由(#157未対応)を明記

## 動作確認
- `./gradlew :app:compileDebugKotlin`(既定=無効) → `BUILD SUCCESSFUL`
- `./gradlew :app:compileDebugKotlin -PfirChecker.enabled=true`(有効化) → 既存の危険な`as`キャスト6件(`RunRoutineViewModel.kt`4件、`RoutineEditViewModel.kt`2件)を検出してコンパイルエラーになることを確認
- `./gradlew :app:ktlintCheck` → `BUILD SUCCESSFUL`
- `./gradlew testDebugUnitTest`(CIと同じタスク、既定=無効) → `BUILD SUCCESSFUL`

## Close対象
close #156

## 補足
- `:app`には現時点で検出対象となる危険な`as`キャストが6件残っているため、`firChecker.enabled`は既定で`false`にしている。これらの棚卸し・修正は#157のスコープ。#157完了後にこのプロパティの既定値を`true`に切り替える想定。
- 今回はGradleの`kotlinCompilerPluginClasspath`への条件付き依存追加という最小構成を採用し、`KotlinCompilerPluginSupportPlugin`によるフル独自Gradleプラグイン化は行っていない(未公開のプロジェクトローカルモジュールをMaven座標で解決させる構成が必要になり複雑さに見合わないと判断)。
